### PR TITLE
Port from libintl to intl.

### DIFF
--- a/atk/build/win32/vs10/atk-build-defines.props
+++ b/atk/build/win32/vs10/atk-build-defines.props
@@ -18,7 +18,7 @@
       <ForcedIncludeFiles>msvc_recommended_pragmas.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>glib-2.0.lib;gobject-2.0.lib;gmodule-2.0.lib;libintl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>glib-2.0.lib;gobject-2.0.lib;gmodule-2.0.lib;intl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(GLibEtcInstallRoot)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>

--- a/atk/build/win32/vs12/atk-build-defines.props
+++ b/atk/build/win32/vs12/atk-build-defines.props
@@ -20,7 +20,7 @@
       <AdditionalOptions>/d2Zi+ %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>glib-2.0.lib;gobject-2.0.lib;gmodule-2.0.lib;libintl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>glib-2.0.lib;gobject-2.0.lib;gmodule-2.0.lib;intl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(GLibEtcInstallRoot)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>$(OutDir)$(AtkDllPrefix)$(ProjectName)$(AtkDllSuffix).pdb</ProgramDatabaseFile>
     </Link>

--- a/atk/mod.md
+++ b/atk/mod.md
@@ -1,6 +1,4 @@
  * Download [ATK 2.18.0](http://ftp.acc.umu.se/pub/GNOME/sources/atk/2.18/atk-2.18.0.tar.xz)
- * In `build\win32\vs12\atk-build-defines.props`, replace:
-	* `intl.lib` with `libintl.lib`
  * In `build\win32\vs12\atk-version-paths.props`, replace:
 	* `<GlibEtcInstallRoot>$(SolutionDir)\..\..\..\..\vs$(VSVer)\$(Platform)</GlibEtcInstallRoot>` with
 `<GlibEtcInstallRoot>$(SolutionDir)\..\..\..\..\..\..\gtk\$(Platform)</GlibEtcInstallRoot>`

--- a/build.ps1
+++ b/build.ps1
@@ -491,6 +491,7 @@ $items['gettext-runtime'].BuildScript = {
 	Remove-Item -Recurse $packageDestination -ErrorAction Ignore
 
 	Exec $patch -p1 -i gettext-runtime.patch
+	Exec $patch -p1 -i gettext-lib-prexif.patch
 
 	Remove-Item -Recurse CMakeCache.txt, CMakeFiles -ErrorAction Ignore
 

--- a/gdk-pixbuf/build/win32/vc10/gdk-pixbuf.props
+++ b/gdk-pixbuf/build/win32/vc10/gdk-pixbuf.props
@@ -92,7 +92,7 @@ cd vs$(VSVer)
       <ForcedIncludeFiles>msvc_recommended_pragmas.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>gio-2.0.lib;gmodule-2.0.lib;gobject-2.0.lib;glib-2.0.lib;gthread-2.0.lib;libintl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gio-2.0.lib;gmodule-2.0.lib;gobject-2.0.lib;glib-2.0.lib;gthread-2.0.lib;intl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(GlibEtcInstallRoot)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PreBuildEvent>

--- a/gdk-pixbuf/build/win32/vs12/gdk-pixbuf-build-defines.props
+++ b/gdk-pixbuf/build/win32/vs12/gdk-pixbuf-build-defines.props
@@ -30,7 +30,7 @@
       <AdditionalOptions>/d2Zi+ %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>gio-2.0.lib;gmodule-2.0.lib;gobject-2.0.lib;glib-2.0.lib;libintl.lib;libpng16.lib;zlib1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gio-2.0.lib;gmodule-2.0.lib;gobject-2.0.lib;glib-2.0.lib;intl.lib;libpng16.lib;zlib1.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(GlibEtcInstallRoot)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>LIBCMTD.lib;LIBCMT.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
     </Link>

--- a/gdk-pixbuf/mod.md
+++ b/gdk-pixbuf/mod.md
@@ -1,6 +1,4 @@
  * Download [GDK-PixBuf 2.32.1](http://ftp.acc.umu.se/pub/GNOME/sources/gdk-pixbuf/2.32/gdk-pixbuf-2.32.1.tar.xz)
- * In `build\win32\vc12\gdk-pixbuf-build-defines.props`, replace:
-	* `intl.lib` with `libintl.lib`
  * In `build\win32\vc12\gdk-pixbuf-version-paths.props`, replace:
 	* `<GlibEtcInstallRoot>$(SolutionDir)\..\..\..\..\vs$(VSVer)\$(Platform)</GlibEtcInstallRoot>` with
 `<GlibEtcInstallRoot>$(SolutionDir)\..\..\..\..\..\..\gtk\$(Platform)</GlibEtcInstallRoot>`

--- a/gettext-runtime/gettext-lib-prexif.patch
+++ b/gettext-runtime/gettext-lib-prexif.patch
@@ -1,0 +1,13 @@
+diff -Naur /c/Users/Clayton/Desktop/difffs/gettext-orig/gettext-runtime/intl/CMakeLists.txt /c/Users/Clayton/Desktop/difffs/gettext-mod/gettext-runtime/intl/CMakeLists.txt
+--- /c/Users/Clayton/Desktop/difffs/gettext-orig/gettext-runtime/intl/CMakeLists.txt	2012-01-21 21:10:25.000000000 -0700
++++ /c/Users/Clayton/Desktop/difffs/gettext-mod/gettext-runtime/intl/CMakeLists.txt	2015-12-02 16:23:51.903960200 -0700
+@@ -55,9 +55,6 @@
+ 
+ add_library(intl ${LIBRARY_TYPE} ${INTL_SRCS})
+ target_link_libraries(intl ${ICONV_LIBRARIES})
+-if(MSVC)
+-set_target_properties(intl PROPERTIES OUTPUT_NAME "libintl")
+-endif(MSVC)
+ 
+ if(WINCE)
+     target_link_libraries(intl ${WCECOMPAT_LIBRARIES})

--- a/gettext-runtime/mod.md
+++ b/gettext-runtime/mod.md
@@ -1,3 +1,4 @@
  * Download [gettext-runtime 0.18](http://winkde.org/pub/kde/ports/win32/repository-4.8/win32libs/gettext-vc100-0.18-src.tar.bz2) from WinKDE
  * Convert `gettext-runtime\intl\intl.def` to Unix EOL
  * Patch with `patch -p1 -i gettext-runtime.patch`
+ * Patch with `patch -p1 -i gettext-lib-prefix.patch`

--- a/glib-networking/build/win32/vs12/glib-networking-build-defines.props
+++ b/glib-networking/build/win32/vs12/glib-networking-build-defines.props
@@ -20,7 +20,7 @@
       <AdditionalOptions>/d2Zi+ %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>gio-2.0.lib;gobject-2.0.lib;glib-2.0.lib;libintl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gio-2.0.lib;gobject-2.0.lib;glib-2.0.lib;intl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(GlibEtcInstallRoot)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>

--- a/glib-networking/mod.md
+++ b/glib-networking/mod.md
@@ -1,6 +1,4 @@
  * Download [glib-networking 2.46.1](https://github.com/nice-software/glib-networking/releases/download/2.46.1-openssl/glib-networking-2.46.1.tar.xz)
- * In `build\win32\vs12\glib-networking-build-defines.props`, replace:
-	* `intl.lib` with `libintl.lib`
  * In `build\win32\vs12\glib-networking-version-paths.props`, replace:
 	* `<GlibEtcInstallRoot>$(SolutionDir)\..\..\..\..\vs$(VSVer)\$(Platform)</GlibEtcInstallRoot>` with
 `<GlibEtcInstallRoot>$(SolutionDir)\..\..\..\..\..\..\gtk\$(Platform)</GlibEtcInstallRoot>`

--- a/glib/build/win32/vs10/glib-build-defines.props
+++ b/glib/build/win32/vs10/glib-build-defines.props
@@ -30,7 +30,7 @@
       <ForcedIncludeFiles>msvc_recommended_pragmas.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>libintl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>intl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(GlibEtcInstallRoot)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>

--- a/glib/build/win32/vs12/glib-build-defines.props
+++ b/glib/build/win32/vs12/glib-build-defines.props
@@ -32,7 +32,7 @@
       <AdditionalOptions>/d2Zi+ %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>libintl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>intl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(GlibEtcInstallRoot)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>

--- a/glib/mod.md
+++ b/glib/mod.md
@@ -2,8 +2,6 @@
  * In all vcxproj files,
 	* add `<Import Project="..\..\..\..\stack.props" />`
 	* remove all `<Optimization>` lines
- * In `build\win32\vs12\glib-build-defines.props`, replace:
-	* `intl.lib` with `libintl.lib`
  * In `build\win32\vs12\glib-version-paths.props`, replace:
 	* `<GlibEtcInstallRoot>..\..\..\..\vs$(VSVer)\$(Platform)</GlibEtcInstallRoot>` with
 `<GlibEtcInstallRoot>..\..\..\..\..\..\gtk\$(Platform)</GlibEtcInstallRoot>`

--- a/gtk/build/win32/vs12/gtk-build-defines.props
+++ b/gtk/build/win32/vs12/gtk-build-defines.props
@@ -25,7 +25,7 @@
       <AdditionalOptions>/d2Zi+ %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
 	<Link>
-      <AdditionalDependencies>pangocairo-1.0.lib;cairo.lib;pango-1.0.lib;gdk_pixbuf-2.0.lib;gio-2.0.lib;gmodule-2.0.lib;gobject-2.0.lib;glib-2.0.lib;libintl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>pangocairo-1.0.lib;cairo.lib;pango-1.0.lib;gdk_pixbuf-2.0.lib;gio-2.0.lib;gmodule-2.0.lib;gobject-2.0.lib;glib-2.0.lib;intl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(GlibEtcInstallRoot)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>

--- a/gtk/mod.md
+++ b/gtk/mod.md
@@ -1,6 +1,4 @@
  * Download [GTK+ 2.24.28](http://ftp.gnome.org/pub/gnome/sources/gtk+/2.24/gtk+-2.24.28.tar.xz)
- * In `build\win32\vs12\gtk-build-defines.props`, replace:
-	* `intl.lib` with `libintl.lib`
  * In `build\win32\vs12\gtk-install.props`:
 	* Add `;$(BinDir)\libpixmap.dll` to `<InstalledDlls>`
 	* Add to `<GtkDoInstall`:

--- a/gtk3/build/win32/vs10/gtk-build-defines.props
+++ b/gtk3/build/win32/vs10/gtk-build-defines.props
@@ -23,7 +23,7 @@
       <ForcedIncludeFiles>msvc_recommended_pragmas.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
 	<Link>
-      <AdditionalDependencies>pangocairo-1.0.lib;cairo.lib;cairo-gobject.lib;pango-1.0.lib;gdk_pixbuf-2.0.lib;gio-2.0.lib;gmodule-2.0.lib;gobject-2.0.lib;glib-2.0.lib;libintl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>pangocairo-1.0.lib;cairo.lib;cairo-gobject.lib;pango-1.0.lib;gdk_pixbuf-2.0.lib;gio-2.0.lib;gmodule-2.0.lib;gobject-2.0.lib;glib-2.0.lib;intl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(GlibEtcInstallRoot)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>

--- a/gtk3/build/win32/vs12/gtk3-build-defines.props
+++ b/gtk3/build/win32/vs12/gtk3-build-defines.props
@@ -25,7 +25,7 @@
       <AdditionalOptions>/d2Zi+ %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
 	<Link>
-      <AdditionalDependencies>pangocairo-1.0.lib;cairo.lib;cairo-gobject.lib;pango-1.0.lib;gdk_pixbuf-2.0.lib;gio-2.0.lib;gmodule-2.0.lib;gobject-2.0.lib;glib-2.0.lib;libintl.lib;epoxy.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>pangocairo-1.0.lib;cairo.lib;cairo-gobject.lib;pango-1.0.lib;gdk_pixbuf-2.0.lib;gio-2.0.lib;gmodule-2.0.lib;gobject-2.0.lib;glib-2.0.lib;intl.lib;epoxy.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(GlibEtcInstallRoot)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>

--- a/gtk3/mod.md
+++ b/gtk3/mod.md
@@ -1,6 +1,4 @@
  * Download [GTK+ 3.18.5](http://ftp.acc.umu.se/pub/GNOME/sources/gtk+/3.18/gtk+-3.18.5.tar.xz)
- * In `build\win32\vs12\gtk3-build-defines.props`, replace:
-	* `intl.lib` with `libintl.lib`
  * In `build\win32\vs12\gtk3-version-paths.props`, replace:
 	* `<GlibEtcInstallRoot>$(SolutionDir)\..\..\..\..\vs$(VSVer)\$(Platform)</GlibEtcInstallRoot>` with
 `<GlibEtcInstallRoot>$(SolutionDir)\..\..\..\..\..\..\gtk\$(Platform)</GlibEtcInstallRoot>`

--- a/libsoup/build/win32/vs12/soup-build-defines.props
+++ b/libsoup/build/win32/vs12/soup-build-defines.props
@@ -21,7 +21,7 @@
       <AdditionalOptions>/d2Zi+ %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>libxml2.lib;gio-2.0.lib;gobject-2.0.lib;glib-2.0.lib;libintl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libxml2.lib;gio-2.0.lib;gobject-2.0.lib;glib-2.0.lib;intl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(GlibEtcInstallRoot)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>

--- a/pango/build/win32/vs10/pango-build-defines.props
+++ b/pango/build/win32/vs10/pango-build-defines.props
@@ -21,7 +21,7 @@
       <ForcedIncludeFiles>msvc_recommended_pragmas.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>gmodule-2.0.lib;gobject-2.0.lib;glib-2.0.lib;libintl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gmodule-2.0.lib;gobject-2.0.lib;glib-2.0.lib;intl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(GlibEtcInstallRoot)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>

--- a/pango/build/win32/vs12/pango-build-defines.props
+++ b/pango/build/win32/vs12/pango-build-defines.props
@@ -23,7 +23,7 @@
       <AdditionalOptions>/d2Zi+ %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>gmodule-2.0.lib;gobject-2.0.lib;glib-2.0.lib;libintl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gmodule-2.0.lib;gobject-2.0.lib;glib-2.0.lib;intl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(GlibEtcInstallRoot)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>$(OutDir)$(PangoDllPrefix)$(ProjectName)$(PangoDllSuffix).pdb</ProgramDatabaseFile>
     </Link>

--- a/pango/mod.md
+++ b/pango/mod.md
@@ -2,8 +2,6 @@
  * In all vcxproj files,
 	* add `<Import Project="..\..\..\..\stack.props" />`
 	* remove all `<Optimization>` lines
- * In `build\win32\vs12\pango-build-defines.props`, replace:
-	* `intl.lib` with `libintl.lib`
  * In `build\win32\vs12\pango-version-paths.props`, replace:
 	* `<GlibEtcInstallRoot>$(SolutionDir)\..\..\..\..\vs$(VSVer)\$(Platform)</GlibEtcInstallRoot>` with
 `<GlibEtcInstallRoot>$(SolutionDir)\..\..\..\..\..\..\gtk\$(Platform)</GlibEtcInstallRoot>`


### PR DESCRIPTION
Part of a move towards using upstream solution files is moving from libintl to intl. As such I've changed almost all instances of libintl to intl as preparation.